### PR TITLE
Revised Subheading and removed the redundant word "also"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ displayed in a GUI window.
     Example:
         $ python asdl2sexp.py myast.ast
 
-###The output of the program:   
+### Program Output:   
     The program will produce the output file <input_filename>.sexpr, containing the s-expression
     corresponding to your supplied AST. If you have Tcl/tk installed and the file viewtree.tk in
-    your current working directory, the graphical tree for the AST will also be displayed.
+    your current working directory, the graphical tree for the AST will be displayed.
 
     Example:
         $ python asdl2exp.py myast.abc


### PR DESCRIPTION
-Changed the subheading of the paragraph to "Program output"
-Removed the word "also" in the last sentence, as it was redundant and wasn't adding any value to the sentence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eyeezzi/asdl-to-sexp/2)
<!-- Reviewable:end -->
